### PR TITLE
Removal of master-slave phrasing

### DIFF
--- a/src/olfactometer_arduino.py
+++ b/src/olfactometer_arduino.py
@@ -442,7 +442,7 @@ class MFC(QWidget):
         self.olfa_communication = monitor
         self.parent_olfactometer = parent
         self.mfcindex = mfcindex  # index of MFC in the module
-        self.olfactometer_address = olfactometer_address  # index of the slave in the system
+        self.olfactometer_address = olfactometer_address  # index of the subordinate in the system
         self.flow = 0
         if name == "Air":
             self.mfccapacity = 1000


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.